### PR TITLE
Handle faulty empty attribute options

### DIFF
--- a/oscar_elasticsearch/search/models.py
+++ b/oscar_elasticsearch/search/models.py
@@ -93,13 +93,18 @@ if is_model_registered("catalogue", "Product"):
             values = self.attribute_values.all().select_related("attribute")
             result = {}
             for value in values:
-                at = value.attribute
-                if at.type == at.OPTION:
-                    result[value.attribute.code] = value.value.option
-                elif at.type == at.MULTI_OPTION:
-                    result[value.attribute.code] = [a.option for a in value.value]
-                elif es_type_for_product_attribute(at) != "text":
-                    result[value.attribute.code] = value.value
+                try:
+                    at = value.attribute
+                    if at.type == at.OPTION:
+                        result[value.attribute.code] = value.value.option
+                    elif at.type == at.MULTI_OPTION:
+                        result[value.attribute.code] = [a.option for a in value.value]
+                    elif (
+                        es_type_for_product_attribute(at) != "text"
+                    ):  # text can not be indexed properly.
+                        result[value.attribute.code] = value.value
+                except AttributeError:  # an option was empty
+                    pass
 
             if self.is_parent:
                 for child in ProductProxy.objects.filter(parent=self):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 
 setup(


### PR DESCRIPTION
When attributes are switched from one type to another, and they are some type of option, the values will be None, causing an attributeerror.

No reason to make the index update fail.