### PR TITLE
add namespace 'search'

### DIFF
--- a/oscar_elasticsearch/search/apps.py
+++ b/oscar_elasticsearch/search/apps.py
@@ -12,6 +12,8 @@ class OscarElasticSearchConfig(OscarConfig):
     name = "oscar_elasticsearch.search"
     verbose_name = _("Elasticsearch")
 
+    namespace = 'search'
+
     def ready(self):
         self.search_view = get_class("search.views", "CatalogueSearchView")
         self.autocomplete_view = get_class("search.views", "CatalogueAutoCompleteView")


### PR DESCRIPTION
no reverse() functions found only template url tags that already use the namespace