### PR TITLE
Prevent high memory usage when reindexing objects

### DIFF
--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from oscar.core.loading import get_class, get_model
 
+chunked = get_class("search.utils", "chunked")
 CategoryElasticsearchIndex = get_class(
     "search.api.category", "CategoryElasticsearchIndex"
 )
@@ -12,7 +13,10 @@ Category = get_model("catalogue", "Category")
 class Command(BaseCommand):
     def handle(self, *args, **options):
         categories = Category.objects.browsable()
-        CategoryElasticsearchIndex().reindex(categories)
+
+        for chunk in chunked(categories, 100):
+            CategoryElasticsearchIndex().reindex(chunk)
+
         self.stdout.write(
             self.style.SUCCESS(
                 "%i categories successfully indexed" % categories.count()

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -2,6 +2,7 @@ from django.core.management.base import BaseCommand
 
 from oscar.core.loading import get_class, get_model
 
+chunked = get_class("search.utils", "chunked")
 ProductElasticsearchIndex = get_class("search.api.product", "ProductElasticsearchIndex")
 
 Product = get_model("catalogue", "Product")
@@ -10,7 +11,10 @@ Product = get_model("catalogue", "Product")
 class Command(BaseCommand):
     def handle(self, *args, **options):
         products = Product.objects.browsable()
-        ProductElasticsearchIndex().reindex(products)
+
+        for chunk in chunked(products, 100):
+            ProductElasticsearchIndex().reindex(chunk)
+
         self.stdout.write(
             self.style.SUCCESS("%i products successfully indexed" % products.count())
         )


### PR DESCRIPTION
Previously, if you had a large catalogue and reindexed the products, it would lead to high memory usage and a likely crash.
This is also how the helpers.py has implemented the `update_index_products` function, probably for the same reason.