### PR TITLE
Update index commands should use update_or_create

### DIFF
--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -21,7 +21,7 @@ class Command(BaseCommand):
             CategoryElasticsearchIndex().reindex(categories)
 
         for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
-            CategoryElasticsearchIndex().reindex(chunk)
+            CategoryElasticsearchIndex().update_or_create(chunk)
             self.stdout.write(".", ending="")
 
         self.stdout.write(

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             ProductElasticsearchIndex().reindex(products)
 
         for chunk in chunked(products, settings.INDEXING_CHUNK_SIZE):
-            ProductElasticsearchIndex().reindex(chunk)
+            ProductElasticsearchIndex().update_or_create(chunk)
             self.stdout.write(".", ending="")
 
         self.stdout.write(

--- a/oscar_elasticsearch/search/settings.py
+++ b/oscar_elasticsearch/search/settings.py
@@ -1,7 +1,6 @@
 # pylint: disable=wildcard-import,unused-wildcard-import
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from django.utils.functional import lazy
 
 # from extendedsearch.settings import *
 from .constants import ES_CTX_AVAILABLE, ES_CTX_PUBLIC
@@ -136,6 +135,4 @@ DEFAULT_ORDERING = getattr(settings, "OSCAR_ELASTICSEARCH_DEFAULT_ORDERING", Non
 
 FACET_BUCKET_SIZE = getattr(settings, "OSCAR_ELASTICSEARCH_FACET_BUCKET_SIZE", 10)
 
-INDEXING_CHUNK_SIZE = lazy(
-    lambda: getattr(settings, "OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE", 100), int
-)()
+INDEXING_CHUNK_SIZE = getattr(settings, "OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE", 100)

--- a/oscar_elasticsearch/search/settings.py
+++ b/oscar_elasticsearch/search/settings.py
@@ -1,6 +1,7 @@
 # pylint: disable=wildcard-import,unused-wildcard-import
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
+from django.utils.functional import lazy
 
 # from extendedsearch.settings import *
 from .constants import ES_CTX_AVAILABLE, ES_CTX_PUBLIC
@@ -135,4 +136,6 @@ DEFAULT_ORDERING = getattr(settings, "OSCAR_ELASTICSEARCH_DEFAULT_ORDERING", Non
 
 FACET_BUCKET_SIZE = getattr(settings, "OSCAR_ELASTICSEARCH_FACET_BUCKET_SIZE", 10)
 
-INDEXING_CHUNK_SIZE = getattr(settings, "OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE", 100)
+INDEXING_CHUNK_SIZE = lazy(
+    lambda: getattr(settings, "OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE", 100), int
+)()

--- a/oscar_elasticsearch/search/tests.py
+++ b/oscar_elasticsearch/search/tests.py
@@ -1,8 +1,9 @@
 import doctest
+from unittest.mock import patch
 
 from time import sleep
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 
 from oscar.core.loading import get_class, get_model
@@ -157,7 +158,7 @@ class ManagementCommandsTestCase(TestCase):
         self.assertEqual(results.count(), 4)
         self.assertEqual(total_hits, 4)
 
-    @override_settings(OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE=2)
+    @patch("oscar_elasticsearch.search.settings.INDEXING_CHUNK_SIZE", 2)
     def test_update_index_products_multiple_chunks(self):
         results, total_hits = self.product_index.search()
         self.assertEqual(results.count(), 0)
@@ -182,7 +183,7 @@ class ManagementCommandsTestCase(TestCase):
         self.assertEqual(results.count(), 2)
         self.assertEqual(total_hits, 2)
 
-    @override_settings(OSCAR_ELASTICSEARCH_INDEXING_CHUNK_SIZE=1)
+    @patch("oscar_elasticsearch.search.settings.INDEXING_CHUNK_SIZE", 1)
     def test_update_index_categories_multiple_chunks(self):
         results, total_hits = self.category_index.search()
         self.assertEqual(results.count(), 0)


### PR DESCRIPTION
Update index commands should use update_or_create, not reindex as it's processed in chunks which means it would loose data if there are multiple chunks.