### PR TITLE
Update index commands should use reindex

### DIFF
--- a/oscar_elasticsearch/search/api/category.py
+++ b/oscar_elasticsearch/search/api/category.py
@@ -34,7 +34,9 @@ class CategoryElasticsearchIndex(BaseElasticSearchApi, ESModelIndexer):
     def make_documents(self, objects):
         from oscar_odin.mappings import catalogue
 
-        CategoryMapping = get_class("search.mappings.categories", "CategoryMapping")
+        CategoryElasticSearchMapping = get_class(
+            "search.mappings.categories", "CategoryElasticSearchMapping"
+        )
 
         # the transaction and the select_for_update are candidates for removal!
         with transaction.atomic():
@@ -42,7 +44,9 @@ class CategoryElasticsearchIndex(BaseElasticSearchApi, ESModelIndexer):
                 objects = objects.select_for_update()
 
             category_resources = catalogue.CategoryToResource.apply(objects)
-            category_document_resources = CategoryMapping.apply(category_resources)
+            category_document_resources = CategoryElasticSearchMapping.apply(
+                category_resources
+            )
 
             return dict_codec.dump(
                 category_document_resources, include_type_field=False

--- a/oscar_elasticsearch/search/api/product.py
+++ b/oscar_elasticsearch/search/api/product.py
@@ -62,7 +62,6 @@ class ProductElasticsearchIndex(BaseElasticSearchApi, ESModelIndexer):
             objects = objects.select_for_update()
 
             product_resources = catalogue.product_queryset_to_resources(objects)
-
             product_document_resources = ProductElasticSearchMapping.apply(
                 product_resources
             )

--- a/oscar_elasticsearch/search/indexing/indexer.py
+++ b/oscar_elasticsearch/search/indexing/indexer.py
@@ -117,18 +117,24 @@ class ESModelIndexer(BaseModelIndex):
         (es_data,) = self.make_documents([obj])
         self.indexer.index(obj.id, es_data["_source"])
 
-    def bulk_index(self, objects):
-        es_data = self.make_documents(objects)
-        return self.indexer.bulk_index(es_data)
-
     @contextmanager
     def reindex(self):
+        """
+        Example usage:
+        with CategoryElasticsearchIndex().reindex() as index:
+            for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
+                index.reindex_objects(chunk)
+        """
         self.indexer.start()
 
         try:
             yield self
         finally:
             self.indexer.finish()
+
+    def reindex_objects(self, objects):
+        es_data = self.make_documents(objects)
+        return self.indexer.execute(es_data)
 
     def delete(self, _id):
         return self.indexer.delete_doc(_id)

--- a/oscar_elasticsearch/search/indexing/indexer.py
+++ b/oscar_elasticsearch/search/indexing/indexer.py
@@ -9,7 +9,6 @@ from elasticsearch.exceptions import NotFoundError
 
 from oscar_elasticsearch.search.api.base import BaseModelIndex
 
-chunked = get_class("search.utils", "chunked")
 es = get_class("search.backend", "es")
 
 

--- a/oscar_elasticsearch/search/indexing/indexer.py
+++ b/oscar_elasticsearch/search/indexing/indexer.py
@@ -21,6 +21,11 @@ class Indexer(object):
         self.mappings = mappings
         self.settings = settings
 
+        # Sometimes you might process docs in chunks, in this case you don't want to clean up
+        # old aliases on each chunk, as it's possible that alias has not yet been processed.
+        # In this case you can exclude alias from cleanup by adding it to this list.
+        self.excluded_cleanup_aliases = []
+
     def execute(self, documents):
         self.start()
         self.bulk_index(documents, self.alias_name)
@@ -71,7 +76,10 @@ class Indexer(object):
 
             # Cleanup old aliased
             for index in aliased_indices:
-                if index != self.alias_name:
+                if (
+                    index != self.alias_name
+                    and index not in self.excluded_cleanup_aliases
+                ):
                     self.delete(index)
         else:
             self.delete(self.name)

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -29,6 +29,7 @@ class Command(BaseCommand):
 
         for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
             category_index.reindex(chunk, manage_alias_lifecycle=False)
+            self.stdout.write(".", ending="")
 
         category_index.indexer.finish()
 

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -20,8 +20,12 @@ class Command(BaseCommand):
         if not categories:
             CategoryElasticsearchIndex().reindex(categories)
 
+        alias_indexes = []
         for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
-            CategoryElasticsearchIndex().update_or_create(chunk)
+            category_index = CategoryElasticsearchIndex()
+            alias_indexes.append(category_index.indexer.alias_name)
+            category_index.indexer.excluded_cleanup_aliases = alias_indexes
+            category_index.reindex(chunk)
             self.stdout.write(".", ending="")
 
         self.stdout.write(

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -16,14 +16,6 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         categories = Category.objects.browsable()
 
-        # When there are no categories, we should still reindex to clear the index
-        if not categories:
-            CategoryElasticsearchIndex().reindex_objects(categories)
-            self.stdout.write(
-                self.style.WARNING("no browsable categories, index cleared.")
-            )
-            return
-
         with CategoryElasticsearchIndex().reindex() as index:
             for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
                 index.reindex_objects(chunk)

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -20,6 +20,7 @@ class Command(BaseCommand):
             for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
                 index.reindex_objects(chunk)
                 self.stdout.write(".", ending="")
+                self.stdout.flush()  # Ensure the dots are displayed immediately
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -26,7 +26,7 @@ class Command(BaseCommand):
 
         with CategoryElasticsearchIndex().reindex() as index:
             for chunk in chunked(categories, settings.INDEXING_CHUNK_SIZE):
-                index.bulk_index(chunk)
+                index.reindex_objects(chunk)
                 self.stdout.write(".", ending="")
 
         self.stdout.write(

--- a/oscar_elasticsearch/search/management/commands/update_index_categories.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_categories.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
 
         # When there are no categories, we should still reindex to clear the index
         if not categories:
-            CategoryElasticsearchIndex().execute(categories)
+            CategoryElasticsearchIndex().reindex_objects(categories)
             self.stdout.write(
                 self.style.WARNING("no browsable categories, index cleared.")
             )

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -1,3 +1,5 @@
+import time
+
 from django.core.management.base import BaseCommand
 
 from oscar.core.loading import get_class, get_model
@@ -12,20 +14,51 @@ Product = get_model("catalogue", "Product")
 
 class Command(BaseCommand):
     def handle(self, *args, **options):
-        products = Product.objects.browsable()
+        # Record the start time for the entire indexing process
+        overall_start_time = time.time()
+
+        products = Product.objects.browsable().distinct()
+        products_total = products.count()
 
         # When there are no products, we should still reindex to clear the index
-        if not products:
-            ProductElasticsearchIndex().reindex(products)
+        if products_total == 0:
+            ProductElasticsearchIndex().reindex([])
+            self.stdout.write(
+                self.style.WARNING("no browsable products, index cleared.")
+            )
+            return
 
-        alias_indexes = []
+        product_index = ProductElasticsearchIndex()
+        product_index.indexer.start()
+
+        total_chunks = products_total / settings.INDEXING_CHUNK_SIZE
+        processed_chunks = 0
+
         for chunk in chunked(products, settings.INDEXING_CHUNK_SIZE):
-            product_index = ProductElasticsearchIndex()
-            alias_indexes.append(product_index.indexer.alias_name)
-            product_index.indexer.excluded_cleanup_aliases = alias_indexes
-            product_index.reindex(chunk)
-            self.stdout.write(".", ending="")
+            chunk_index_time = time.time()
+            product_index.reindex(chunk, manage_alias_lifecycle=False)
+            processed_chunks += 1
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Processed chunk %i of %i (%i/%s products indexed) in %.2f seconds"
+                    % (
+                        processed_chunks,
+                        total_chunks,
+                        min(
+                            processed_chunks * settings.INDEXING_CHUNK_SIZE,
+                            products_total,
+                        ),
+                        products_total,
+                        time.time() - chunk_index_time,
+                    )
+                )
+            )
+
+        product_index.indexer.finish()
 
         self.stdout.write(
-            self.style.SUCCESS("\n%i products successfully indexed" % products.count())
+            self.style.SUCCESS(
+                "\n%i products successfully indexed in %.2f seconds"
+                % (products_total, time.time() - overall_start_time)
+            )
         )

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -17,17 +17,8 @@ class Command(BaseCommand):
         # Record the start time for the entire indexing process
         overall_start_time = time.time()
 
-        products = Product.objects.browsable()
+        products = Product.objects.all()
         products_total = products.count()
-
-        # When there are no products, we should still reindex to clear the index
-        if products_total == 0:
-            ProductElasticsearchIndex().reindex_objects([])
-            self.stdout.write(
-                self.style.WARNING("no browsable products, index cleared.")
-            )
-            return
-
         total_chunks = products_total / settings.INDEXING_CHUNK_SIZE
         processed_chunks = 0
 

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
 
         # When there are no products, we should still reindex to clear the index
         if products_total == 0:
-            ProductElasticsearchIndex().reindex([])
+            ProductElasticsearchIndex().reindex_objects([])
             self.stdout.write(
                 self.style.WARNING("no browsable products, index cleared.")
             )

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         # Record the start time for the entire indexing process
         overall_start_time = time.time()
 
-        products = Product.objects.all()
+        products = Product.objects.browsable()
         products_total = products.count()
         total_chunks = products_total / settings.INDEXING_CHUNK_SIZE
         processed_chunks = 0

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         with ProductElasticsearchIndex().reindex() as index:
             for chunk in chunked(products, settings.INDEXING_CHUNK_SIZE):
                 chunk_index_time = time.time()
-                index.bulk_index(chunk)
+                index.reindex_objects(chunk)
                 processed_chunks += 1
                 self.stdout.write(
                     self.style.SUCCESS(

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -18,8 +18,12 @@ class Command(BaseCommand):
         if not products:
             ProductElasticsearchIndex().reindex(products)
 
+        alias_indexes = []
         for chunk in chunked(products, settings.INDEXING_CHUNK_SIZE):
-            ProductElasticsearchIndex().update_or_create(chunk)
+            product_index = ProductElasticsearchIndex()
+            alias_indexes.append(product_index.indexer.alias_name)
+            product_index.indexer.excluded_cleanup_aliases = alias_indexes
+            product_index.reindex(chunk)
             self.stdout.write(".", ending="")
 
         self.stdout.write(

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -17,7 +17,7 @@ class Command(BaseCommand):
         # Record the start time for the entire indexing process
         overall_start_time = time.time()
 
-        products = Product.objects.browsable().distinct()
+        products = Product.objects.browsable()
         products_total = products.count()
 
         # When there are no products, we should still reindex to clear the index

--- a/oscar_elasticsearch/search/mappings/categories.py
+++ b/oscar_elasticsearch/search/mappings/categories.py
@@ -20,7 +20,6 @@ Category = get_model("catalogue", "Category")
 class CategoryElasticSearchResource(OscarElasticSearchResourceMixin):
     full_name: str
     full_slug: str
-    _index: str
 
 
 class CategoryMapping(OscarBaseMapping):
@@ -46,10 +45,6 @@ class CategoryMapping(OscarBaseMapping):
             return self.source.code
 
         return "%s-%s" % (self.source.slug, self.source.id)
-
-    @odin.assign_field
-    def _index(self) -> str:
-        return self.context.get("_index")
 
 
 class ElasticSearchResource(OscarResource):

--- a/oscar_elasticsearch/search/mappings/products/__init__.py
+++ b/oscar_elasticsearch/search/mappings/products/__init__.py
@@ -10,7 +10,7 @@ from oscar_odin.resources.catalogue import (
 from oscar_odin.mappings._common import OscarBaseMapping
 
 ProductElasticSearchResource = get_class(
-    "search.mappings.products.mappings", "ProductElasticSearchResource"
+    "search.mappings.products.resources", "ProductElasticSearchResource"
 )
 ProductMapping = get_class("search.mappings.products.mappings", "ProductMapping")
 

--- a/oscar_elasticsearch/search/tests.py
+++ b/oscar_elasticsearch/search/tests.py
@@ -140,10 +140,15 @@ class ManagementCommandsTestCase(TestCase):
     ]
 
     def setUp(self):
-        self.product_index = ProductElasticsearchIndex()
-        self.product_index.reindex(Product.objects.none())
-        self.category_index = CategoryElasticsearchIndex()
-        self.category_index.reindex([])
+        # Clear index before each test
+        with ProductElasticsearchIndex().reindex() as index:
+            self.product_index = index
+            index.reindex_objects(Product.objects.none())
+
+        with CategoryElasticsearchIndex().reindex() as index:
+            self.category_index = index
+            index.reindex_objects([])
+
         super().setUp()
 
     def test_update_index_products(self):

--- a/oscar_elasticsearch/search/utils.py
+++ b/oscar_elasticsearch/search/utils.py
@@ -1,7 +1,9 @@
-from django.db.models import Case, When
+import itertools
+
+from django.db.models import Case, When, QuerySet
 
 
-def chunked(qs, size, startindex=0):
+def chunked(iterable, size, startindex=0):
     """
     Divide an interable into chunks of ``size``
 
@@ -10,14 +12,22 @@ def chunked(qs, size, startindex=0):
     >>> list(chunked([1,2,3,4,5,6,7], 3))
     [[1, 2, 3], [4, 5, 6], [7]]
     """
-    while True:
-        chunk = qs[startindex : startindex + size]
-        chunklen = len(chunk)
-        if chunklen:
+    if isinstance(iterable, QuerySet):
+        iterator = iterable.iterator(chunk_size=size)
+        while True:
+            chunk = list(itertools.islice(iterator, size))
+            if not chunk:
+                break
             yield chunk
-        if chunklen < size:
-            break
-        startindex += size
+    else:
+        while True:
+            chunk = iterable[startindex : startindex + size]
+            chunklen = len(chunk)
+            if chunklen:
+                yield chunk
+            if chunklen < size:
+                break
+            startindex += size
 
 
 def search_result_to_queryset(search_results, Model):


### PR DESCRIPTION
- Replace `update_or_create` with `reindex`
- Add 'manage_alias_lifecycle' argument to reindex, so you can do this yourself in say bulk ops
- Use django's iterator() method in the chunked util to prevent loaded whole QS in memory
- Fix categories make_documents, as it didn't make use of the correct mapper