### PR TITLE
Improve performance by removing N+1 queries 

### DIFF
--- a/oscar_elasticsearch/search/api/product.py
+++ b/oscar_elasticsearch/search/api/product.py
@@ -1,7 +1,10 @@
 from odin.codecs import dict_codec
 
 from django.db import transaction
-from django.db.models import QuerySet
+from django.db.models import QuerySet, OuterRef, Count, Subquery
+from django.utils import timezone
+
+from dateutil.relativedelta import relativedelta
 
 from oscar.core.loading import get_class, get_model, get_classes
 from oscar_elasticsearch.search import settings
@@ -24,6 +27,7 @@ from oscar_elasticsearch.search import settings
 BaseElasticSearchApi = get_class("search.api.search", "BaseElasticSearchApi")
 ESModelIndexer = get_class("search.indexing.indexer", "ESModelIndexer")
 Product = get_model("catalogue", "Product")
+Line = get_model("order", "Line")
 
 
 class ProductElasticsearchIndex(BaseElasticSearchApi, ESModelIndexer):
@@ -57,11 +61,24 @@ class ProductElasticsearchIndex(BaseElasticSearchApi, ESModelIndexer):
             "search.mappings.products", "ProductElasticSearchMapping"
         )
 
-        # the transaction and the select_for_update are candidates for removal!
-        with transaction.atomic():
-            objects = objects.select_for_update()
+        # Annotate the queryset with popularity to avoid the need of n+1 queries
+        objects = objects.annotate(
+            popularity=Subquery(
+                Line.objects.filter(
+                    product_id=OuterRef("id"),
+                    order__date_placed__gte=timezone.now()
+                    - relativedelta(months=settings.MONTHS_TO_RUN_ANALYTICS),
+                )
+                .annotate(popularity_count=Count("id"))
+                .values("popularity_count")
+            )
+        )
 
-            product_resources = catalogue.product_queryset_to_resources(objects)
+        # the transaction is candidate for removal!
+        with transaction.atomic():
+            product_resources = catalogue.product_queryset_to_resources(
+                objects, include_children=True
+            )
             product_document_resources = ProductElasticSearchMapping.apply(
                 product_resources
             )

--- a/oscar_elasticsearch/search/mappings/categories.py
+++ b/oscar_elasticsearch/search/mappings/categories.py
@@ -8,8 +8,6 @@ from oscar_odin.resources.catalogue import Category as CategoryResource
 from oscar_odin.mappings._common import OscarBaseMapping
 from oscar_odin.resources._base import OscarResource
 
-from django.contrib.contenttypes.models import ContentType
-
 OscarElasticSearchResourceMixin = get_class(
     "search.mappings.mixins", "OscarElasticSearchResourceMixin"
 )
@@ -28,8 +26,7 @@ class CategoryMapping(OscarBaseMapping):
 
     @odin.assign_field
     def content_type(self) -> str:
-        content_type = ContentType.objects.get_for_model(Category)
-        return ".".join(content_type.natural_key())
+        return "catalogue.category"
 
     @odin.map_field(from_field="name", to_field=["title", "search_title"])
     def title(self, name) -> str:

--- a/oscar_elasticsearch/search/mappings/products/mappings.py
+++ b/oscar_elasticsearch/search/mappings/products/mappings.py
@@ -1,6 +1,5 @@
 import odin
 
-from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django.utils.html import strip_tags
 from django.db.models import QuerySet
@@ -71,6 +70,14 @@ class ProductMapping(OscarBaseMapping):
 
     @odin.assign_field
     def popularity(self):
+        # In our search.api.product make_documents method, we annotate the popularity, this way
+        # we don't have to do N+1 queries to get the popularity of each product.
+        if hasattr(self.source, "model_instance") and hasattr(
+            self.source.model_instance, "popularity"
+        ):
+            return self.source.model_instance.popularity
+
+        # Fallback to n+1 query, though, try to avoid this.
         months_to_run = settings.MONTHS_TO_RUN_ANALYTICS
         orders_above_date = timezone.now() - relativedelta(months=months_to_run)
 
@@ -80,8 +87,7 @@ class ProductMapping(OscarBaseMapping):
 
     @odin.assign_field
     def content_type(self) -> str:
-        content_type = ContentType.objects.get_for_model(Product)
-        return ".".join(content_type.natural_key())
+        return "catalogue.product"
 
     @odin.assign_field(to_list=True)
     def categories(self) -> str:
@@ -131,11 +137,9 @@ class ProductMapping(OscarBaseMapping):
     def string_attrs(self):
         attrs = [str(a) for a in self.source.attributes.values()]
         if self.source.structure == Product.PARENT:
-            for child in Product.objects.filter(parent_id=self.source.id):
+            for child in self.source.children:
                 attrs.append(child.title)
-                attrs.extend(
-                    [str(a.value_as_text) for a in child.get_attribute_values()]
-                )
+                attrs.extend([str(a.value_as_text) for a in child.attributes.values()])
 
         return attrs
 


### PR DESCRIPTION
Prevent doing N+1 queries, to improve overall performance.

Depends on;
https://github.com/django-oscar/django-oscar/pull/4350 & https://github.com/django-oscar/django-oscar-odin/pull/39/files to be merged.

Dummy DB with barely any attributes;
`1000001 products successfully indexed in 364.46 seconds`

PRD DB with 384846 products and 8876914 total attribute values:
`Processed chunk 1 of 384 (1000/384846 products indexed) in 2.53 seconds`

Which would first be > 10 seconds for each chunk, sometimes even 20 seconds.