### PR TITLE
Using django's iterator is not really neccesary and add .distinct() on product queryset

### DIFF
--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         This is useful when debugging the performance of the indexing process.
         """
         overall_start_time = time.time()
-        products = Product.objects.browsable()
+        products = Product.objects.browsable().distinct()
         products_total = products.count()
         total_chunks = products_total / settings.INDEXING_CHUNK_SIZE
         processed_chunks = 0

--- a/oscar_elasticsearch/search/management/commands/update_index_products.py
+++ b/oscar_elasticsearch/search/management/commands/update_index_products.py
@@ -39,7 +39,7 @@ class Command(BaseCommand):
         This is useful when debugging the performance of the indexing process.
         """
         overall_start_time = time.time()
-        products = Product.objects.browsable().distinct()
+        products = Product.objects.browsable()
         products_total = products.count()
         total_chunks = products_total / settings.INDEXING_CHUNK_SIZE
         processed_chunks = 0

--- a/oscar_elasticsearch/search/utils.py
+++ b/oscar_elasticsearch/search/utils.py
@@ -12,22 +12,14 @@ def chunked(iterable, size, startindex=0):
     >>> list(chunked([1,2,3,4,5,6,7], 3))
     [[1, 2, 3], [4, 5, 6], [7]]
     """
-    if isinstance(iterable, QuerySet):
-        iterator = iterable.iterator(chunk_size=size)
-        while True:
-            chunk = list(itertools.islice(iterator, size))
-            if not chunk:
-                break
+    while True:
+        chunk = iterable[startindex : startindex + size]
+        chunklen = len(chunk)
+        if chunklen:
             yield chunk
-    else:
-        while True:
-            chunk = iterable[startindex : startindex + size]
-            chunklen = len(chunk)
-            if chunklen:
-                yield chunk
-            if chunklen < size:
-                break
-            startindex += size
+        if chunklen < size:
+            break
+        startindex += size
 
 
 def search_result_to_queryset(search_results, Model):

--- a/oscar_elasticsearch/search/utils.py
+++ b/oscar_elasticsearch/search/utils.py
@@ -1,6 +1,4 @@
-import itertools
-
-from django.db.models import Case, When, QuerySet
+from django.db.models import Case, When
 
 
 def chunked(iterable, size, startindex=0):


### PR DESCRIPTION
I thought that when slicing, it still consumed a lot of memory and that's why I added the use of .iterator() in the chunked util.
However, after testing, slicing works fine and and it's probably better to keep it simple and use slicing.