### PR TITLE
Add support for nested fields

### DIFF
--- a/oscar_elasticsearch/search/api/search.py
+++ b/oscar_elasticsearch/search/api/search.py
@@ -95,13 +95,22 @@ def get_elasticsearch_aggs(aggs_definitions):
     for facet_definition in aggs_definitions:
         name = facet_definition["name"]
         facet_type = facet_definition["type"]
+        nested = facet_definition.get("nested", None)
         if facet_type == "term":
             terms = {"terms": {"field": name, "size": es_settings.FACET_BUCKET_SIZE}}
 
             if "order" in facet_definition:
                 terms["terms"]["order"] = {"_key": facet_definition.get("order", "asc")}
 
-            aggs[name] = terms
+            if nested:
+                aggs[name] = {
+                    "nested": {"path": nested["path"]},
+                    "aggs": {
+                        name: terms,
+                    },
+                }
+            else:
+                aggs[name] = terms
         elif facet_type == "range":
             ranges_definition = facet_definition["ranges"]
             if ranges_definition:

--- a/oscar_elasticsearch/search/facets.py
+++ b/oscar_elasticsearch/search/facets.py
@@ -38,8 +38,13 @@ def process_facets(request_full_path, form, facets, facet_definitions=None):
         if unfiltered_facet is None:
             continue
 
-        unfiltered_buckets = unfiltered_facet.get("buckets", [])
-        filtered_buckets = filtered_facet.get("buckets", [])
+        if "nested" in facet_definition:
+            unfiltered_buckets = unfiltered_facet[facet_name].get("buckets", [])
+            filtered_buckets = filtered_facet[facet_name].get("buckets", [])
+        else:
+            unfiltered_buckets = unfiltered_facet.get("buckets", [])
+            filtered_buckets = filtered_facet.get("buckets", [])
+
         if len(unfiltered_buckets) >= settings.MIN_NUM_BUCKETS:
             # range facet buckets are always filled so we need to check if the
             # doc_counts are non-zero to know if they are useful.

--- a/oscar_elasticsearch/search/views/base.py
+++ b/oscar_elasticsearch/search/views/base.py
@@ -89,9 +89,29 @@ class BaseSearchView(ListView):
                             {"range": {name: {"from": D(from_), "to": D(to)}}}
                         )
 
-                filters.append({"bool": {"should": ranges}})
+                if definition.get("nested", None):
+                    filters.append(
+                        {
+                            "nested": {
+                                "path": definition["nested"]["path"],
+                                "query": {"bool": {"should": ranges}},
+                            }
+                        }
+                    )
+                else:
+                    filters.append({"bool": {"should": ranges}})
             else:
-                filters.append({"terms": {name: value}})
+                if definition.get("nested", None):
+                    filters.append(
+                        {
+                            "nested": {
+                                "path": definition["nested"]["path"],
+                                "query": {"terms": {name: value}},
+                            }
+                        }
+                    )
+                else:
+                    filters.append({"terms": {name: value}})
 
         return filters
 

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "setuptools",
         "django-oscar>=4.0a1",
         "purl",
-        "elasticsearch>=8.0.0;<9",
+        "elasticsearch>=8.0.0,<9",
         "uwsgidecorators-fallback",
         "django-oscar-odin>=0.3.0",
         "python-dateutil>=2.8.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "setuptools",
         "django-oscar>=4.0a1",
         "purl",
-        "elasticsearch>=8.0.0",
+        "elasticsearch>=8.0.0;<9",
         "uwsgidecorators-fallback",
         "django-oscar-odin>=0.3.0",
         "python-dateutil>=2.8.0",


### PR DESCRIPTION
Updated facets, filters, and aggregations to handle nested fields, enabling more flexible query structures. Adjusted logic to check for "nested" definitions and construct queries accordingly, ensuring compatibility with both standard and nested data structures.

This PR improves the handling of nested fields.

Let's take category as an example.
The following snippet shows how to add a facet for the category id.
A new dictionary key "nested" is needed with the "path" to be used.

```

OSCAR_ELASTICSEARCH_FACETS = [
    {
        "name": "categories.id",
        "label": "Category",
        "type": "term",
        "nested": {
            "path": "categories",
        }
}
```
