### PR TITLE
Restrict elasticsearch to v8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "setuptools",
         "django-oscar>=4.0a1",
         "purl",
-        "elasticsearch>=8.0.0",
+        "elasticsearch>=8.0.0,<9    ",
         "uwsgidecorators-fallback",
         "django-oscar-odin>=0.3.0",
         "python-dateutil>=2.8.0",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "setuptools",
         "django-oscar>=4.0a1",
         "purl",
-        "elasticsearch>=8.0.0,<9    ",
+        "elasticsearch>=8.0.0,<9",
         "uwsgidecorators-fallback",
         "django-oscar-odin>=0.3.0",
         "python-dateutil>=2.8.0",


### PR DESCRIPTION
Elasticsearch v9 (just released) introduces breaking changes.
It now raises a BadRequestError(400, 'media_type_header_exception', 'Invalid media-type value on headers [Accept, Content-Type]')
This commit restricts the package to v8
