### PR TITLE
Include child product attributes in parent product facets

### DIFF
--- a/oscar_elasticsearch/search/fixtures/catalogue/catalogue.json
+++ b/oscar_elasticsearch/search/fixtures/catalogue/catalogue.json
@@ -770,6 +770,69 @@
     }
 },
 {
+    "model": "catalogue.productattributevalue",
+    "pk": 23,
+    "fields": {
+        "attribute": 11,
+        "product": 6,
+        "value_text": "parent henkie value",
+        "value_integer": null,
+        "value_boolean": null,
+        "value_float": null,
+        "value_richtext": null,
+        "value_date": null,
+        "value_datetime": null,
+        "value_option": null,
+        "value_file": "",
+        "value_image": "",
+        "entity_content_type": null,
+        "entity_object_id": null,
+        "value_multi_option": []
+    }
+},
+{
+    "model": "catalogue.productattributevalue",
+    "pk": 24,
+    "fields": {
+        "attribute": 11,
+        "product": 7,
+        "value_text": "child henkie value",
+        "value_integer": null,
+        "value_boolean": null,
+        "value_float": null,
+        "value_richtext": null,
+        "value_date": null,
+        "value_datetime": null,
+        "value_option": null,
+        "value_file": "",
+        "value_image": "",
+        "entity_content_type": null,
+        "entity_object_id": null,
+        "value_multi_option": []
+    }
+},
+{
+    "model": "catalogue.productattributevalue",
+    "pk": 25,
+    "fields": {
+        "attribute": 2,
+        "product": 7,
+        "value_text": "child subtitle value",
+        "value_integer": null,
+        "value_boolean": null,
+        "value_float": null,
+        "value_richtext": null,
+        "value_date": null,
+        "value_datetime": null,
+        "value_option": null,
+        "value_file": "",
+        "value_image": "",
+        "entity_content_type": null,
+        "entity_object_id": null,
+        "value_multi_option": []
+    }
+},
+{
     "model": "catalogue.attributeoptiongroup",
     "pk": 1,
     "fields": {

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -283,6 +283,18 @@ OSCAR_ELASTICSEARCH_FACETS = [
         "label": "Bijzonderheden",
         "type": "term",
         "ranges": []
+    },
+    {
+        "name": "attrs.henkie",
+        "label": "Henk",
+        "type": "term",
+        "ranges": []
+    },
+    {
+        "name": "attrs.subtitle",
+        "label": "Subtitle",
+        "type": "term",
+        "ranges": []
     }
 ]
 


### PR DESCRIPTION
When filtering products by attributes like color or size, parent products only appear if they have those attributes set directly. This means a parent with children in different colors won't show up when filtering by color.

This PR merges child attributes into their parent's facets, so parent products appear when any child matches the selected filter.